### PR TITLE
CORE-5619: Add TldInfo validation patch for .cl domains

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
         "patches": {
             "io-developer/php-whois": {
                 "CORE-5619: Add CLST/CLT timezone support for .cl domains": "components/modules/generic_domains/patches/php-whois-clst-timezone.patch",
-                "CORE-5619: Configure .cl TLD to use commonFlat parser": "components/modules/generic_domains/patches/php-whois-cl-parser.patch"
+                "CORE-5619: Configure .cl TLD to use commonFlat parser": "components/modules/generic_domains/patches/php-whois-cl-parser.patch",
+                "CORE-5619: Relax TldInfo validation to allow responses without domainName": "components/modules/generic_domains/patches/php-whois-tldinfo-validation.patch"
             }
         }
     }

--- a/patches/php-whois-tldinfo-validation.patch
+++ b/patches/php-whois-tldinfo-validation.patch
@@ -1,0 +1,11 @@
+--- a/src/Iodev/Whois/Modules/Tld/TldInfo.php
++++ b/src/Iodev/Whois/Modules/Tld/TldInfo.php
+@@ -122,7 +122,7 @@ class TldInfo extends DataObject
+         if (!empty($badFirstStatesDict[$firstState])) {
+             return false;
+         }
+-        $primaryKeys = ['domainName'];
++        $primaryKeys = [];
+         $secondaryKeys = [
+             "states",
+             "nameServers",


### PR DESCRIPTION
Add third patch to relax TldInfo validation, allowing WHOIS responses without a domainName field to be considered valid. This fixes .cl domains incorrectly reporting as available when they have registration data (dates, nameServers, etc.) but no domainName in the response.